### PR TITLE
chore: add owner_uid to session

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -24,15 +24,15 @@ func InitReporter(ctx context.Context, usageClient usagePB.UsageServiceClient, s
 //	*usagePB.SessionReport_ConnectorUsageData
 //	*usagePB.SessionReport_ModelUsageData
 //	*usagePB.SessionReport_PipelineUsageData
-func StartReporter(ctx context.Context, reporter reporter.Reporter, sessionService usagePB.Session_Service, edition, version string, retrieveUsageData func() interface{}) error {
-	go reporter.Report(ctx, sessionService, edition, version, retrieveUsageData)
+func StartReporter(ctx context.Context, reporter reporter.Reporter, sessionService usagePB.Session_Service, edition, version string, ownerUid string, retrieveUsageData func() interface{}) error {
+	go reporter.Report(ctx, sessionService, edition, version, ownerUid,retrieveUsageData)
 
 	return nil
 }
 
 // SingleReporter uses a usage reporter and sends one-time usage data to server
-func SingleReporter(ctx context.Context, reporter reporter.Reporter, sessionService usagePB.Session_Service, edition, version string, usageData interface{}) error {
-	err := reporter.SingleReport(ctx, sessionService, edition, version, usageData)
+func SingleReporter(ctx context.Context, reporter reporter.Reporter, sessionService usagePB.Session_Service, edition, version string, ownerUid string, usageData interface{}) error {
+	err := reporter.SingleReport(ctx, sessionService, edition, version, ownerUid,usageData)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ retract v0.2.0-alpha
 
 require (
 	github.com/catalinc/hashcash v0.0.0-20220723060415-5e3ec3e24f67
-	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230622154941-b51cc4cf49d0
+	github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc
 	google.golang.org/protobuf v1.30.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 h1:YBftPWNWd4WwGqtY2yeZL2ef8rH
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230622154941-b51cc4cf49d0 h1:dgp/7h66FUQwMoWsFZC/auRKJlBHQ2aACdfskl2W6RA=
 github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230622154941-b51cc4cf49d0/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc h1:1akaOOUCsVU2yzFIb5KwVw5GRy7v+hyNmNmJD+2x+l8=
+github.com/instill-ai/protogen-go v0.3.3-alpha.0.20230814104042-37ca0356defc/go.mod h1:qsq5ecnA1xi2rLnVQFo/9xksA7I7wQu8c7rqM5xbIrQ=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
Because

- avoid complex query for usage metric

This commit

- add `owner_uid` to session
