### PR TITLE
chore(reporter): fix first session report has nil owneruid

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -9,8 +9,8 @@ import (
 )
 
 // InitReporter creates a usage reporter
-func InitReporter(ctx context.Context, usageClient usagePB.UsageServiceClient, sessionService usagePB.Session_Service, edition, version string) (reporter.Reporter, error) {
-	reporter, err := reporter.NewReporter(ctx, usageClient, sessionService, edition, version)
+func InitReporter(ctx context.Context, usageClient usagePB.UsageServiceClient, sessionService usagePB.Session_Service, edition, version string, defaultOwnerUid string) (reporter.Reporter, error) {
+	reporter, err := reporter.NewReporter(ctx, usageClient, sessionService, edition, version, defaultOwnerUid)
 	if err != nil {
 		return nil, err
 	}
@@ -25,14 +25,14 @@ func InitReporter(ctx context.Context, usageClient usagePB.UsageServiceClient, s
 //	*usagePB.SessionReport_ModelUsageData
 //	*usagePB.SessionReport_PipelineUsageData
 func StartReporter(ctx context.Context, reporter reporter.Reporter, sessionService usagePB.Session_Service, edition, version string, ownerUid string, retrieveUsageData func() interface{}) error {
-	go reporter.Report(ctx, sessionService, edition, version, ownerUid,retrieveUsageData)
+	go reporter.Report(ctx, sessionService, edition, version, ownerUid, retrieveUsageData)
 
 	return nil
 }
 
 // SingleReporter uses a usage reporter and sends one-time usage data to server
 func SingleReporter(ctx context.Context, reporter reporter.Reporter, sessionService usagePB.Session_Service, edition, version string, ownerUid string, usageData interface{}) error {
-	err := reporter.SingleReport(ctx, sessionService, edition, version, ownerUid,usageData)
+	err := reporter.SingleReport(ctx, sessionService, edition, version, ownerUid, usageData)
 	if err != nil {
 		return err
 	}

--- a/reporter/reporter.go
+++ b/reporter/reporter.go
@@ -57,7 +57,7 @@ type reporter struct {
 }
 
 // NewReporter creates a new usage reporter
-func NewReporter(ctx context.Context, client usagePB.UsageServiceClient, service usagePB.Session_Service, edition, version string) (Reporter, error) {
+func NewReporter(ctx context.Context, client usagePB.UsageServiceClient, service usagePB.Session_Service, edition, version string, defaultOwnerUid string) (Reporter, error) {
 
 	// Create the session
 	resp, err := client.CreateSession(ctx,
@@ -70,6 +70,7 @@ func NewReporter(ctx context.Context, client usagePB.UsageServiceClient, service
 				Os:         runtime.GOOS,
 				Uptime:     0,
 				ReportTime: timestamppb.New(time.Now()),
+				OwnerUid:   defaultOwnerUid,
 			},
 		})
 	if err != nil {


### PR DESCRIPTION
Because

- update createSession to include `OwnerUid` to prevent some record has `nil` owner_uid value

This commit

- update `NewReporter` request
